### PR TITLE
Families - Fix families listing

### DIFF
--- a/src/app/family/family.component.html
+++ b/src/app/family/family.component.html
@@ -15,38 +15,19 @@
           <mat-label>Last Name</mat-label>
           <input [(ngModel)]="lastName" name="lastName" value="lastName" matInput placeholder="Last Name">
         </mat-form-field>
-      
+
        <button mat-raised-button (click)="[addEntry(), createNewFamily()]">Add Family</button>
 
        <br/>
 
-       <button mat-raised-button (click)="[addEntry(), getFamilies()]">View Families</button>
+       <button mat-raised-button (click)="getFamilies()">View Families</button>
 
        <br/>
-       
+
        <button mat-raised-button (click)="goToPage('home')">Back</button>
 
       </form>
     </mat-card>
-
-    <h3 class="p-3 text-center">Added Families</h3>
-<div class="container box" style="marign-top:10px;">
-    <table class="table table-striped">
-          <thead>
-            <tr>
-              <td style="text-align:center"></td>
-                <th>Family</th>
-                <th>Status</th>
-            <tr>
-          </thead>
-        <tbody>
-          <tr *ngFor="let entry of Families">
-            <th scope="row"></th>
-              <td>{{entry.family}}</td>
-              <td>{{entry.status}}</td>
-          </tr>
-        </tbody>
-      </table>
 
       <h3 class="p-3 text-center">All Families</h3>
 <div class="container box" style="marign-top:10px;">
@@ -61,7 +42,7 @@
         <tbody>
           <tr *ngFor="let entry of Families">
             <th scope="row"></th>
-              <td>{{entry.family}}</td>
+              <td>{{entry.familyName}}</td>
               <td>{{entry.status}}</td>
           </tr>
         </tbody>

--- a/src/app/family/family.component.ts
+++ b/src/app/family/family.component.ts
@@ -14,10 +14,10 @@ export class FamilyComponent implements OnInit {
   family!: string;
   status!: string;
   Families: any = [];
-  
+
 
   constructor(private router: Router, private familyService: FamilyService) {
-    
+
     this.firstName = ""
     this.lastName = ""
     this.family =  ""
@@ -25,6 +25,7 @@ export class FamilyComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.getFamilies()
   }
 
   createNewFamily(){
@@ -40,17 +41,18 @@ export class FamilyComponent implements OnInit {
 
   getFamilies(){
     let familyInfo:any = []
-    this.familyService.getFamily().subscribe((res: any) => { 
-     let arr = res
-     arr.forEach((element: any) => {
+    this.familyService.getFamily().subscribe((res: any) => {
+      let arr = res
+      arr.forEach((element: any) => {
       // console.log(element)
-      
-       familyInfo.push(element)
-     });
-        
+
+        familyInfo.push(element)
+      });
+
     });
 
     console.log(familyInfo);
+    this.Families = familyInfo
   }
 
   updateFamilies(){
@@ -75,7 +77,7 @@ export class FamilyComponent implements OnInit {
   addEntry():void{
     console.log()
     let entry = {
-      family: this.firstName + " " + this.lastName,
+      familyName: this.firstName + " " + this.lastName,
       status: this.status
     }
     this.Families.push(entry)


### PR DESCRIPTION
## What/Why

This branch is built on top of the `Test` branch 🚨 

There were some issues with Families page not properly fetching all the families.  Additionally we were doubling the `*ngFor` with the same data.  I went ahead and removed one of the loops.

To fix the fetching of the families I did the following:

1. Properly referenced the each item in the Family's array with their `familyName` key. This is what is set when the data is written to Mongo and can be seen via: `/api/family`
2. Set `this.Families` once we `getFamilies()`.  The issue there was the data was fetched and not put anywhere.
3. Added `getFamilies()` to `ngOnInit()`.  This way all the families populate on initial load without having to explicitly click the View Families button.  The View Families button now refreshes the list.